### PR TITLE
Upgraded Gson to 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.2.4</version><!-- current version is 2.3 for more information see #11 -->
+			<version>2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
Originally the change to version 2.2.4 was just a workaround, because the pom of gson was malformed. it seems this error has been fixed, thus the workaround is now obsolete
