### PR TITLE
minor fixes and development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,15 @@
 					</descriptorRefs>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.3.2</version>
+				<configuration>
+					<mainClass>com.gmail.inverseconduit.Main</mainClass>
+					<cleanupDaemonThreads>false</cleanupDaemonThreads>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>

--- a/src/main/java/com/gmail/inverseconduit/chat/StackExchangeChat.java
+++ b/src/main/java/com/gmail/inverseconduit/chat/StackExchangeChat.java
@@ -230,7 +230,11 @@ public class StackExchangeChat implements ChatInterface {
     }
 
     /**
-     * {@inheritDoc}
+     * Queries the 5 latest messages for all chatrooms and enqueues them to
+     * the subscribed {@link ChatWorker Workers}, respecting the already handled
+     * timestamps as maintained internally.
+     *
+     * @see ChatInterface#queryMessages()
      */
     @Override
     public void broadcast(final String message) {

--- a/src/main/java/com/gmail/inverseconduit/scripts/ScriptRunner.java
+++ b/src/main/java/com/gmail/inverseconduit/scripts/ScriptRunner.java
@@ -55,8 +55,8 @@ public class ScriptRunner {
         }
         LOGGER.info("Result:" + result);
         return result == null
-            ? String.format(":%d [tag:groovy]: no result", msg.getMessageId())
-            : String.format(":%d [tag:groovy]: %s", msg.getMessageId(), result.toString());
+            ? "[tag:groovy]: no result"
+            : String.format("[tag:groovy]: %s", result.toString());
     }
 
     public void evaluateAndCache(String commandText) {


### PR DESCRIPTION
Fix for a merge-conflict and double replies in the "eval"-command.

Also added a maven goal `exec:java` to start the bot with maven.

These commits are mostly cherry-picked from https://github.com/Unihedro/JavaBot/tree/fix-issue33